### PR TITLE
add linguist override

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+file-types/** linguist-vendored


### PR DESCRIPTION
Excluded `file-types/` from stats (https://github.com/miguelsolorio/vscode-symbols/pull/84#issuecomment-1536458749)

Before:
![image](https://user-images.githubusercontent.com/112294217/236552072-b8cfd5c0-1284-4c1f-b1fb-ae43ddf10a73.png)

After:
![image](https://user-images.githubusercontent.com/112294217/236552034-ac7f956e-041b-49be-808c-4db91da5cd39.png)
