### PR TITLE
Feat: Customization of folders and files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ node_modules
 .vscode-test/
 *.vsix
 src/symbol-icon-theme.modified.json
+src/symbol-icon-theme.bkp.json
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "symbols",
-  "version": "0.0.7",
+  "version": "0.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "symbols",
-      "version": "0.0.7",
+      "version": "0.0.10",
       "devDependencies": {
         "@types/vscode": "^1.70.0",
         "release-it": "^15.3.0"

--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
           "type": "boolean",
           "default": false,
           "description": "Hide arrow icons in the explorer section."
+        },
+        "symbols.folders.associations": {
+          "type": "object",
+          "default": {},
+          "description": "With this configuration can customize the folder icons."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,11 @@
           "type": "object",
           "default": {},
           "description": "With this configuration can customize the folder icons."
+        },
+        "symbols.files.associations": {
+          "type": "object",
+          "default": {},
+          "description": "With this configuration can customize the files icons."
         }
       }
     }

--- a/src/lib/change-listener.js
+++ b/src/lib/change-listener.js
@@ -13,9 +13,7 @@ function monitorConfigChanges() {
   const updatedKeys = {};
 
   for (let currentKey in currentState) {
-    if (currentState[currentKey] != workspaceState[currentKey]) {
-      updatedKeys[currentKey] = workspaceState[currentKey];
-    }
+    updatedKeys[currentKey] = workspaceState[currentKey];
   }
   
   updateConfig(updatedKeys);

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -3,8 +3,8 @@ const vscode = require("vscode");
 const defaultConfig = require("../symbol-icon-theme.json");
 const pkgConfig = require("../../package.json");
 const { getThemeFile, writeThemeFile } = require("./theme");
-const {PKG_PROP_MAP} = require("./constants")
-
+const { PKG_PROP_MAP } = require("./constants")
+const { updateThemeJSONHandlers } = require("./theme-json-handlers")
 
 
 // get the configuration definition from the package.json
@@ -63,8 +63,11 @@ function updateConfig(config) {
 
   for (let key in config) {
     console.log(`symbols.${key} changed, updating to ${config[key]}`);
-    vscode.workspace.getConfiguration("symbols").update(key, config[key], true);
-    themeJSON.hidesExplorerArrows = config[key];
+    const updateHandler = updateThemeJSONHandlers[key];
+    if (updateHandler) {
+      vscode.workspace.getConfiguration("symbols").update(key, config[key], true);
+      updateHandler(themeJSON, config[key]);
+    }
   }
 
   writeThemeFile(themeJSON);

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -2,7 +2,7 @@ const vscode = require("vscode");
 
 const defaultConfig = require("../symbol-icon-theme.json");
 const pkgConfig = require("../../package.json");
-const { getThemeFile, writeThemeFile } = require("./theme");
+const { getSoureFile, writeThemeFile } = require("./theme");
 const { PKG_PROP_MAP } = require("./constants")
 const { updateThemeJSONHandlers } = require("./theme-json-handlers")
 
@@ -59,7 +59,7 @@ function themeJSONToConfig(themeDef) {
  * in the theme definition file
  */
 function updateConfig(config) {
-  const themeJSON = getThemeFile();
+  const themeJSON = getSoureFile();
 
   for (let key in config) {
     console.log(`symbols.${key} changed, updating to ${config[key]}`);

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,6 +1,7 @@
 // mapped properties for keys in package.json vs keys in vscode
 const PKG_PROP_MAP = {
   "symbols.hidesExplorerArrows": "hidesExplorerArrows",
+  "symbols.folders.associations": "folders.associations"
 };
 
 const MESSAGES = {

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,7 +1,8 @@
 // mapped properties for keys in package.json vs keys in vscode
 const PKG_PROP_MAP = {
   "symbols.hidesExplorerArrows": "hidesExplorerArrows",
-  "symbols.folders.associations": "folders.associations"
+  "symbols.folders.associations": "folders.associations",
+  "symbols.files.associations": "files.associations"
 };
 
 const MESSAGES = {

--- a/src/lib/theme-json-handlers.js
+++ b/src/lib/theme-json-handlers.js
@@ -1,0 +1,14 @@
+const updateThemeJSONHandlers = {
+  "hidesExplorerArrows": (themeJSON, value) => {
+    themeJSON.hidesExplorerArrows = value;
+  },
+  "folders.associations": (themeJSON, folders) => {
+    for (const folder in folders) {
+      themeJSON.folderNames[folder] = folders[folder];
+    }
+  },
+};
+
+module.exports = {
+  updateThemeJSONHandlers,
+};

--- a/src/lib/theme-json-handlers.js
+++ b/src/lib/theme-json-handlers.js
@@ -7,6 +7,11 @@ const updateThemeJSONHandlers = {
       themeJSON.folderNames[folder] = folders[folder];
     }
   },
+  "files.associations": (themeJSON, files) => {
+    for (const file in files) {
+      themeJSON.fileNames[file] = files[file];
+    }
+  },
 };
 
 module.exports = {

--- a/src/lib/theme.js
+++ b/src/lib/theme.js
@@ -87,22 +87,7 @@ async function syncOriginal() {
 
   // shallow check
   for (const key in originalJSON) {
-    if (configurableKeys.indexOf(key) > -1) {
-      continue;
-    }
-
-    const stringifiedSource = JSON.stringify(originalJSON[key]);
-    if (!themeJSON[key]) {
-      needsSync = true;
-      break;
-    }
-
-    const stringifiedTheme = JSON.stringify(themeJSON[key]);
-    if (stringifiedSource != stringifiedTheme) {
-      console.log({
-        stringifiedSource,
-        stringifiedTheme,
-      });
+    if (configurableKeys.indexOf(key) > -1 && themeJSON[key] !== originalJSON[key]) {
       needsSync = true;
       break;
     }

--- a/src/lib/theme.js
+++ b/src/lib/theme.js
@@ -106,12 +106,12 @@ async function syncOriginal() {
       needsSync = true;
       break;
     }
+  }
 
-    if (needsSync) {
-      await confirmReload();
-      fs.unlinkSync(themePath);
-      fs.copyFileSync(getDefaultFilePath(), themePath);
-    }
+  if (needsSync) {
+    await confirmReload();
+    fs.unlinkSync(themePath);
+    fs.copyFileSync(getDefaultFilePath(), themePath);
   }
 }
 

--- a/src/lib/theme.js
+++ b/src/lib/theme.js
@@ -87,16 +87,31 @@ async function syncOriginal() {
 
   // shallow check
   for (const key in originalJSON) {
-    if (configurableKeys.indexOf(key) > -1 && themeJSON[key] !== originalJSON[key]) {
+    if (configurableKeys.indexOf(key) > -1) {
+      continue;
+    }
+
+    const stringifiedSource = JSON.stringify(originalJSON[key]);
+    if (!themeJSON[key]) {
       needsSync = true;
       break;
     }
-  }
 
-  if (needsSync) {
-    await confirmReload();
-    fs.unlinkSync(themePath);
-    fs.copyFileSync(getDefaultFilePath(), themePath);
+    const stringifiedTheme = JSON.stringify(themeJSON[key]);
+    if (stringifiedSource != stringifiedTheme) {
+      console.log({
+        stringifiedSource,
+        stringifiedTheme,
+      });
+      needsSync = true;
+      break;
+    }
+
+    if (needsSync) {
+      await confirmReload();
+      fs.unlinkSync(themePath);
+      fs.copyFileSync(getDefaultFilePath(), themePath);
+    }
   }
 }
 

--- a/src/lib/theme.js
+++ b/src/lib/theme.js
@@ -117,6 +117,7 @@ async function syncOriginal() {
 
 module.exports = {
   getThemeFile,
+  getSoureFile,
   writeThemeFile,
   syncOriginal,
 };


### PR DESCRIPTION
This pull request adds a new feature to the project, specifically the ability to customize the icons of folders and files using the `settings.json`.

Solving this issue: [Add the possibility to set folders/files associations #73](https://github.com/miguelsolorio/vscode-symbols/issues/73)

Example:

| config | workspace |
|:--------:|:--------:|
| ![Screenshot 2023-05-21 at 15 40 02](https://github.com/miguelsolorio/vscode-symbols/assets/20077278/9f2feef6-02dc-4a98-a629-28fa9ba4d017) | ![Screenshot 2023-05-21 at 15 39 53](https://github.com/miguelsolorio/vscode-symbols/assets/20077278/7816993f-7382-466c-b148-fc1205486cbf) |



