### PR TITLE
Feat: Wildcards for files association

### DIFF
--- a/src/lib/theme-json-handlers.js
+++ b/src/lib/theme-json-handlers.js
@@ -9,7 +9,12 @@ const updateThemeJSONHandlers = {
   },
   "files.associations": (themeJSON, files) => {
     for (const file in files) {
-      themeJSON.fileNames[file] = files[file];
+      if(file.startsWith('*.')){
+        const newExtension = file.replace('*.','');
+        themeJSON.fileExtensions[newExtension] = files[file];
+      } else {
+        themeJSON.fileNames[file] = files[file];
+      }
     }
   },
 };


### PR DESCRIPTION
This Pull Request introduces a new feature, wildcards for file customization.

Solving this issue: [Allow wildcards in files association #93](https://github.com/miguelsolorio/vscode-symbols/issues/93)

__Example:__

| config | workspace |
|:--------:|:--------:|
| ![Screenshot 2023-06-11 at 13 24 26](https://github.com/miguelsolorio/vscode-symbols/assets/20077278/fbfab172-c0bd-4d96-be08-427cd3d4b467) | ![Screenshot 2023-06-11 at 13 17 45](https://github.com/miguelsolorio/vscode-symbols/assets/20077278/97f3a1d7-3916-4ca6-80d4-930151a5ab5a) |





