### PR TITLE
Use deno icon for `deno.jsonc`

### DIFF
--- a/src/symbol-icon-theme.json
+++ b/src/symbol-icon-theme.json
@@ -499,6 +499,7 @@
     "go.work": "go-mod",
     "go.work.sum": "go-mod",
     "deno.json": "deno",
+    "deno.jsonc": "deno",
     "netlify.json": "netlify",
     "netlify.yml": "netlify",
     "netlify.yaml": "netlify",


### PR DESCRIPTION
Deno supports `.json` as well as `.jsonc` for its config file. More info [here](https://deno.com/manual@v1.34.3/getting_started/configuration_file#configuration-file).

This PR adds support for `deno.jsonc` file. I have used the same deno icon which is currently being used for `deno.json`.