### PR TITLE
Add new color folder for `.nuxt`

### DIFF
--- a/src/symbol-icon-theme.json
+++ b/src/symbol-icon-theme.json
@@ -1280,6 +1280,7 @@
 		".vscode": "folder-blue",
 		".next": "folder-gray",
 		".turbo": "folder-red",
+		".nuxt": "folder-green",
 		".contentlayer": "folder-purple",
 		"node_modules": "folder-green",
 		".github": "folder-github",


### PR DESCRIPTION
Hi @miguelsolorio,

Seeing that the `.next` folder has a color folder I realized that the `.nuxt` folder was also missing its color folder.

Thank for reading