### PR TITLE
Add `utils` icon to the tools folder

### DIFF
--- a/src/symbol-icon-theme.json
+++ b/src/symbol-icon-theme.json
@@ -1347,6 +1347,7 @@
 		"public": "folder-purple-outline",
 		"source": "folder-orange-code",
 		"src": "folder-orange-code",
+		"tools": "folder-utils",
 		"lib": "folder-utils",
 		"doc": "folder-blue",
 		"docs": "folder-blue",


### PR DESCRIPTION
Hello @miguelsolorio,

The `tools` folder is a folder quite common among open source projects, and it should already have its icon, nothing better than the utilities icon.

Thank you for reading... 😊