### PR TITLE
👾 Add icon for `postcss.config.mjs`

### DIFF
--- a/src/symbol-icon-theme.json
+++ b/src/symbol-icon-theme.json
@@ -713,6 +713,7 @@
 		"gradle-wrapper.properties": "gradle",
 		"postcss.config.js": "postcss",
 		"postcss.config.cjs": "postcss",
+		"postcss.config.mjs": "postcss",
 		"postcss.config.ts": "postcss",
 		"postcss.config.cts": "postcss",
 		"postcss.config.mts": "postcss",


### PR DESCRIPTION
I've discovered this kind of config for postCss when creating a new NextJs project

![image](https://github.com/miguelsolorio/vscode-symbols/assets/73550760/5e445262-e5b7-4532-86bd-5269abad9b4c)
