### PR TITLE
Update settings configuration logic

### DIFF
--- a/src/lib/change-listener.js
+++ b/src/lib/change-listener.js
@@ -7,24 +7,12 @@ function monitorConfigChanges() {
 	const workspaceState = getWorkspaceConfiguration();
 
 	const updatedKeys = {};
-	let hasChanges = false;
 
 	for (const currentKey in currentState) {
-		if (currentKey in workspaceState) {
-			if (JSON.stringify(workspaceState[currentKey]) !== JSON.stringify(currentState[currentKey])) {
-				updatedKeys[currentKey] = workspaceState[currentKey];
-				hasChanges = true;
-			}
-		} else if (currentState[currentKey] !== undefined) {
-			// The setting was removed, so we need to update it to undefined
-			updatedKeys[currentKey] = undefined;
-			hasChanges = true;
-		}
+		updatedKeys[currentKey] = workspaceState[currentKey];
 	}
 
-	if (hasChanges) {
-		updateConfig(updatedKeys);
-	}
+	updateConfig(updatedKeys);
 }
 
 module.exports = {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -25,12 +25,7 @@ function getWorkspaceConfiguration() {
 
 		const valueGroup = vscode.workspace.getConfiguration("symbols").inspect(PKG_PROP_MAP[key]);
 
-		if (valueGroup.workspaceValue !== undefined) {
-			config[PKG_PROP_MAP[key]] = valueGroup.workspaceValue;
-		} else if (valueGroup.globalValue !== undefined) {
-			config[PKG_PROP_MAP[key]] = valueGroup.globalValue;
-		}
-		// We no longer fall back to defaultState
+		config[PKG_PROP_MAP[key]] = valueGroup.workspaceValue || valueGroup.globalValue || defaultState[PKG_PROP_MAP[key]];
 	}
 
 	return config;
@@ -61,20 +56,11 @@ function updateConfig(config) {
 	const themeJSON = getSoureFile();
 
 	for (const key in config) {
-		if (config[key] === undefined) {
-			log.info(`symbols.${key} removed, updating theme`);
-			vscode.workspace.getConfiguration("symbols").update(key, undefined, true);
-			// Remove the key from themeJSON if it exists
-			if (key in themeJSON) {
-				delete themeJSON[key];
-			}
-		} else {
-			log.info(`symbols.${key} changed, updating to ${config[key]}`);
-			const updateHandler = updateThemeJSONHandlers[key];
-			if (updateHandler) {
-				vscode.workspace.getConfiguration("symbols").update(key, config[key], true);
-				updateHandler(themeJSON, config[key]);
-			}
+		log.info(`🤖 symbols.${key} changed, updating to ${config[key]}`);
+		const updateHandler = updateThemeJSONHandlers[key];
+		if (updateHandler) {
+			vscode.workspace.getConfiguration("symbols").update(key, config[key], true);
+			updateHandler(themeJSON, config[key]);
 		}
 	}
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -59,7 +59,6 @@ function updateConfig(config) {
 		log.info(`🤖 symbols.${key} changed, updating to ${config[key]}`);
 		const updateHandler = updateThemeJSONHandlers[key];
 		if (updateHandler) {
-			vscode.workspace.getConfiguration("symbols").update(key, config[key], true);
 			updateHandler(themeJSON, config[key]);
 		}
 	}


### PR DESCRIPTION
This is to address #232 and #239 and prevent the extension from updating the user's settings while also ensuring the right theme is loaded based on the user's configuration via files/folders association.

https://github.com/user-attachments/assets/d6630f09-279c-4b32-acc3-12de0b5ac3c5




[symbols-0.0.20.vsix.zip](https://github.com/user-attachments/files/16919130/symbols-0.0.20.vsix.zip)
