### PR TITLE
Add icon for .gitlab-ci.yml file

### DIFF
--- a/src/symbol-icon-theme.json
+++ b/src/symbol-icon-theme.json
@@ -629,6 +629,7 @@
 	},
 
 	"fileNames": {
+		".gitlab-ci.yml": "gitlab",
 		"gitlab-ci.yml": "gitlab",
 		"file.config": "gear",
 		"lunaria.config.json": "lunaria",


### PR DESCRIPTION
Hi @miguelsolorio

# Idea
The gitlab icon can now also be seen in the .gitlab-ci.yml file.

# Preview

![image](https://github.com/user-attachments/assets/e6e5ef4f-8069-44bf-bf39-09f4b8beb397)
