### PR TITLE
Add missing file name for tailwind.config.mjs

### DIFF
--- a/src/symbol-icon-theme.json
+++ b/src/symbol-icon-theme.json
@@ -1101,6 +1101,7 @@
 		"tailwind.ts": "tailwind",
 		"tailwind.config.js": "tailwind",
 		"tailwind.config.cjs": "tailwind",
+		"tailwind.config.mjs": "tailwind",
 		"tailwind.config.ts": "tailwind",
 		"tailwind.config.cts": "tailwind",
 		"tailwind.config.mts": "tailwind",


### PR DESCRIPTION
## What does this PR fix?

Fix: #263 
It adds the `tailwind.config.mjs` file name to the `symbol-icon-theme.json` file names list

**Before**:
![image](https://github.com/user-attachments/assets/e0973db3-37ea-49fb-b8a8-2a2313c2dd5f)

**Now**:
![image](https://github.com/user-attachments/assets/0846bc51-2412-4963-abe2-01145c5dc43b)
