### PR TITLE
Add option to exclude default associations

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,11 @@
 					"default": false,
 					"description": "Hide arrow icons in the explorer section."
 				},
+				"symbols.defaultAssociations": {
+					"type": "boolean",
+					"default": true,
+					"description": "Include a set of predefined file and folder associations."
+				},
 				"symbols.folders.associations": {
 					"type": "object",
 					"default": {},

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 				"symbols.defaultAssociations": {
 					"type": "boolean",
 					"default": true,
-					"description": "Include a set of predefined file and folder associations."
+					"description": "Allows you to use the default icons for files and folders or disable them and specify your own via symbols.files.associations and symbols.folders.associations."
 				},
 				"symbols.folders.associations": {
 					"type": "object",

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -55,6 +55,15 @@ function themeJSONToConfig(themeDef) {
 function updateConfig(config) {
 	const themeJSON = getSoureFile();
 
+	const useDefaultAssociations = vscode.workspace.getConfiguration("symbols").get("defaultAssociations", true);
+	log.info(`🤖 symbols.defaultAssociations changed, updating to ${useDefaultAssociations}`);
+	if (useDefaultAssociations === false) {
+		themeJSON.fileExtensions = {};
+		themeJSON.fileNames = {};
+		themeJSON.languageIds = {};
+		themeJSON.folderNames = {};
+	}
+
 	for (const key in config) {
 		log.info(`🤖 symbols.${key} changed, updating to ${config[key]}`);
 		const updateHandler = updateThemeJSONHandlers[key];


### PR DESCRIPTION
closes #265

Adds the `symbols.defaultAssociations` option (set to true by default) that controls whether the default associations defined in the base theme file are included or not.