### PR TITLE
Add icon to Bun text-based lockfiles

### DIFF
--- a/src/symbol-icon-theme.json
+++ b/src/symbol-icon-theme.json
@@ -717,6 +717,7 @@
 		"keystatic.page.ts": "keystatic",
 		"keystatic.config.ts": "keystatic",
 		"bruno.json": "bruno",
+		"bun.lock": "bun",
 		"bun.lockb": "bun",
 		"bunfig.toml": "bun",
 		"dune": "dune",


### PR DESCRIPTION
Bun introduced a new lockfile format in v1.1.39, which will become the default in v1.2.

You can read more about it here: https://bun.sh/blog/bun-lock-text-lockfile